### PR TITLE
Update PDF upload functionality to upload complete PDFs

### DIFF
--- a/app/backend/Services/AzureBlobStorageService.cs
+++ b/app/backend/Services/AzureBlobStorageService.cs
@@ -37,37 +37,19 @@ internal sealed class AzureBlobStorageService(BlobContainerClient container)
                 }
                 else if (Path.GetExtension(fileName).ToLower() is ".pdf")
                 {
-                    using var documents = PdfReader.Open(stream, PdfDocumentOpenMode.Import);
-                    for (int i = 0; i < documents.PageCount; i++)
+                    var blobName = BlobNameFromFilePage(fileName);
+                    var blobClient = container.GetBlobClient(blobName);
+                    if (await blobClient.ExistsAsync(cancellationToken))
                     {
-                        var documentName = BlobNameFromFilePage(fileName, i);
-                        var blobClient = container.GetBlobClient(documentName);
-                        if (await blobClient.ExistsAsync(cancellationToken))
-                        {
-                            continue;
-                        }
-
-                        var tempFileName = Path.GetTempFileName();
-
-                        try
-                        {
-                            using var document = new PdfDocument();
-                            document.AddPage(documents.Pages[i]);
-                            document.Save(tempFileName);
-
-                            await using var tempStream = File.OpenRead(tempFileName);
-                            await blobClient.UploadAsync(tempStream, new BlobHttpHeaders
-                            {
-                                ContentType = "application/pdf"
-                            }, cancellationToken: cancellationToken);
-
-                            uploadedFiles.Add(documentName);
-                        }
-                        finally
-                        {
-                            File.Delete(tempFileName);
-                        }
+                        continue;
                     }
+
+                    await blobClient.UploadAsync(stream, new BlobHttpHeaders
+                    {
+                        ContentType = "application/pdf"
+                    }, cancellationToken: cancellationToken);
+
+                    uploadedFiles.Add(blobName);
                 }
             }
 
@@ -90,6 +72,6 @@ internal sealed class AzureBlobStorageService(BlobContainerClient container)
 
     private static string BlobNameFromFilePage(string filename, int page = 0) =>
         Path.GetExtension(filename).ToLower() is ".pdf"
-            ? $"{Path.GetFileNameWithoutExtension(filename)}-{page}.pdf"
+            ? $"{Path.GetFileNameWithoutExtension(filename)}.pdf"
             : Path.GetFileName(filename);
 }


### PR DESCRIPTION
Update functionality to upload complete PDFs to blob storage without splitting them into pages.

* Modify `app/backend/Services/AzureBlobStorageService.cs` to remove code that splits PDFs into pages before uploading and update the `UploadFilesAsync` method to upload complete PDFs.
* Modify `app/prepdocs/PrepareDocs/Program.cs` to remove code that splits PDFs into pages before uploading and update the `UploadBlobsAndCreateIndexAsync` method to upload complete PDFs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DFMERA/azure-search-openai-demo-csharp/pull/1?shareId=d53143b4-bf20-46cb-a3dd-a30ac83c3877).