### PR TITLE
Fix PDF upload to blob storage

### DIFF
--- a/app/backend/Services/AzureBlobStorageService.cs
+++ b/app/backend/Services/AzureBlobStorageService.cs
@@ -37,37 +37,19 @@ internal sealed class AzureBlobStorageService(BlobContainerClient container)
                 }
                 else if (Path.GetExtension(fileName).ToLower() is ".pdf")
                 {
-                    using var documents = PdfReader.Open(stream, PdfDocumentOpenMode.Import);
-                    for (int i = 0; i < documents.PageCount; i++)
+                    var blobName = BlobNameFromFilePage(fileName);
+                    var blobClient = container.GetBlobClient(blobName);
+                    if (await blobClient.ExistsAsync(cancellationToken))
                     {
-                        var documentName = BlobNameFromFilePage(fileName, i);
-                        var blobClient = container.GetBlobClient(documentName);
-                        if (await blobClient.ExistsAsync(cancellationToken))
-                        {
-                            continue;
-                        }
-
-                        var tempFileName = Path.GetTempFileName();
-
-                        try
-                        {
-                            using var document = new PdfDocument();
-                            document.AddPage(documents.Pages[i]);
-                            document.Save(tempFileName);
-
-                            await using var tempStream = File.OpenRead(tempFileName);
-                            await blobClient.UploadAsync(tempStream, new BlobHttpHeaders
-                            {
-                                ContentType = "application/pdf"
-                            }, cancellationToken: cancellationToken);
-
-                            uploadedFiles.Add(documentName);
-                        }
-                        finally
-                        {
-                            File.Delete(tempFileName);
-                        }
+                        continue;
                     }
+
+                    await blobClient.UploadAsync(stream, new BlobHttpHeaders
+                    {
+                        ContentType = "application/pdf"
+                    }, cancellationToken: cancellationToken);
+
+                    uploadedFiles.Add(blobName);
                 }
             }
 
@@ -90,6 +72,6 @@ internal sealed class AzureBlobStorageService(BlobContainerClient container)
 
     private static string BlobNameFromFilePage(string filename, int page = 0) =>
         Path.GetExtension(filename).ToLower() is ".pdf"
-            ? $"{Path.GetFileNameWithoutExtension(filename)}-{page}.pdf"
+            ? $"{Path.GetFileNameWithoutExtension(filename)}.pdf"
             : Path.GetFileName(filename);
 }

--- a/app/prepdocs/PrepareDocs/Program.cs
+++ b/app/prepdocs/PrepareDocs/Program.cs
@@ -160,43 +160,26 @@ static async ValueTask UploadBlobsAndCreateIndexAsync(
 {
     var container = await GetBlobContainerClientAsync(options);
 
-    // If it's a PDF, split it into single pages.
+    // If it's a PDF, upload the entire file.
     if (Path.GetExtension(fileName).Equals(".pdf", StringComparison.OrdinalIgnoreCase))
     {
-        using var documents = PdfReader.Open(fileName, PdfDocumentOpenMode.Import);
-        for (int i = 0; i < documents.PageCount; i++)
+        var documentName = BlobNameFromFilePage(fileName);
+        var blobClient = container.GetBlobClient(documentName);
+        if (await blobClient.ExistsAsync())
         {
-            var documentName = BlobNameFromFilePage(fileName, i);
-            var blobClient = container.GetBlobClient(documentName);
-            if (await blobClient.ExistsAsync())
-            {
-                continue;
-            }
-
-            var tempFileName = Path.GetTempFileName();
-
-            try
-            {
-                using var document = new PdfDocument();
-                document.AddPage(documents.Pages[i]);
-                document.Save(tempFileName);
-
-                await using var stream = File.OpenRead(tempFileName);
-                await blobClient.UploadAsync(stream, new BlobHttpHeaders
-                {
-                    ContentType = "application/pdf"
-                });
-
-                // revert stream position
-                stream.Position = 0;
-
-                await embeddingService.EmbedPDFBlobAsync(stream, documentName);
-            }
-            finally
-            {
-                File.Delete(tempFileName);
-            }
+            return;
         }
+
+        await using var stream = File.OpenRead(fileName);
+        await blobClient.UploadAsync(stream, new BlobHttpHeaders
+        {
+            ContentType = "application/pdf"
+        });
+
+        // revert stream position
+        stream.Position = 0;
+
+        await embeddingService.EmbedPDFBlobAsync(stream, documentName);
     }
     // if it's an img (end with .png/.jpg/.jpeg), upload it to blob storage and embed it.
     else if (Path.GetExtension(fileName).Equals(".png", StringComparison.OrdinalIgnoreCase) ||
@@ -252,7 +235,7 @@ static string GetContentType(string fileName)
 }
 
 static string BlobNameFromFilePage(string filename, int page = 0) => Path.GetExtension(filename).ToLower() is ".pdf"
-        ? $"{Path.GetFileNameWithoutExtension(filename)}-{page}.pdf"
+        ? $"{Path.GetFileNameWithoutExtension(filename)}.pdf"
         : Path.GetFileName(filename);
 
 internal static partial class Program


### PR DESCRIPTION
Modify the functionality in `PrepareDocs` and `MinimalAPI` to upload complete PDFs to blob storage without splitting them into pages.

* **app/backend/Services/AzureBlobStorageService.cs**
  - Remove the code that splits PDFs into individual pages.
  - Modify the `UploadFilesAsync` method to upload the entire PDF file without splitting it into pages.
  - Ensure the entire PDF file is uploaded to blob storage.

* **app/prepdocs/PrepareDocs/Program.cs**
  - Remove the code that splits PDFs into individual pages.
  - Modify the `UploadBlobsAndCreateIndexAsync` method to upload the entire PDF file without splitting it into pages.
  - Ensure the entire PDF file is uploaded to blob storage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DFMERA/azure-search-openai-demo-csharp/pull/2?shareId=5741fb13-678f-44c9-a60e-d78c771a0315).